### PR TITLE
Add support for new data from appmetrics-1.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ $ npm install appmetrics-statsd
 
 The connector can be used in your application by requiring it as the first line of your application:
 ```sh
-var appstatsd = require('appmetrics-statsd').Client();
+var appstatsd = require('appmetrics-statsd').StatsD();
 ```
-Configuration of the connection to the StatsD server is possible by passing parameters to the `Client()` function. These are passed directly though to the `StatsD` constructor in the `node-statsd` module. Information for that module is available here:
+Configuration of the connection to the StatsD server is possible by passing parameters to the `StatsD()` function. These are passed directly though to the `StatsD` constructor in the `node-statsd` module. Information for that module is available here:
 https://www.npmjs.com/package/node-statsd
 
 Additional data may also be sent to StatsD using the standard `node-statsd` module Client APIs, eg.
@@ -24,26 +24,119 @@ Additional data may also be sent to StatsD using the standard `node-statsd` modu
 ```sh
 var statsd = require('appmetrics-statsd').StatsD();
 
-statsd.guage('gauge', 10.4);
+statsd.gauge('gauge', 10.4);
 ```
 
 ### Data Provided
 
 The connector sends the following data values to StatsD from Node Application Metrics:
-#### Gauges
+
+
+#### CPU
+**Gauges**
+
+* `cpu.process` the CPU usage of the application as a percentage of total machine CPU
+* `cpu.system` the CPU usage of the system as a percentage of total machine CPU
+
+#### System Memory
+
+**Gauges**
+
 * `memory.process.private` the amount of memory used by the Node.js application that cannot be shared with other processes, in bytes.
 * `memory.process.physical` the amount of RAM used by the Node.js application in bytes.
 * `memory.process.virtual` the memory address space used by Node.js application in bytes.
 * `memory.system.used` the total amount of RAM in use on the system in bytes.
 * `memory.system.total` the total amount of RAM available on the system in bytes.
+
+####Event Loop
+
+* `eventloop.latency.min` the shortest sampled latency for processing an event
+* `eventloop.latency.max` the longest sampled latency for processing an event
+* `eventloop.latency.avg` the mean sampled latency for processing an event
+
+####Garbage Collection
+
+**Gauges**
+
 * `gc.size` the size of the JavaScript heap in bytes.
 * `gc.used` the amount of memory used on the JavaScript heap in bytes.
 
-#### Timers
+**Timers**
+
 * `gc.duration` the duration of the GC cycle in milliseconds.
+
+####HTTP Requests
+
+**Timers**
+
+* `http` the time taken for the HTTP request to be responded to in ms.
+
+####Socket.io
+
+**Timers**
+
+* `socketio.broadcast.<event>` the time taken for the broadcast to all clients of the named socketio event.
+* `socketio.emit.<event>` the time taken for the emit to a single client of the named socketio event.
+* `socketio.receive.<event>` the time taken for a received named socketio event to be handled.
+
+####MySQL Queries
+
+**Timers**
+
+* `mysql` the time taken for the given MySQL query to be responded to in ms.
+
+####MongoDB Queries
+
+**Timers**
+
+* `mongo` the time taken for the given MongoDB query to be responded to in ms.
+
+####Leveldown Queries
+
+**Timers**
+
+* `levedown.get` the time taken for the Leveldown `get` to be responded to in ms.
+* `levedown.put` the time taken for the Leveldown `put` to be responded to in ms.
+* `levedown.del` the time taken for the Leveldown `del` to be responded to in ms.
+* `levedown.batch` the time taken for the Leveldown `batch` to be run in ms.
+
+####Redis Queries
+
+**Timers**
+
+* `redis.<cmd>` the time taken for the given Redis command to be responded to in ms.
+
+####Memcached Operations
+
+**Timers**
+
+* `memcached.<method>` the time taken for the given Memcached method to be responded to in ms.
+
+####PostgreSQL Queries
+
+**Timers**
+
+* `postgres` the time taken for the given PostgresSQL query to be responded to in ms.
+
+####MQTT Messaging
+
+**Timers**
+
+* `mqtt.<method>.<topic>` the time taken for a MQTT message to handled on a given topic in ms.
+
+####MQLight Messaging
+
+**Timers**
+
+* `mqlight.<method>.<topic>`  the time taken for a MQLight message to handled on a given topic in ms.
 
 ### License
 The Node Application Metrics to StatsD Connector is licensed using an Apache v2.0 License.
 
 ### Version
-1.0.0
+1.0.1
+
+#### Version History
+
+1.0.1 Add support for Event Loop, HTTP, Socketio, MongoDB, MySQL, Leveldown, Redis, Memcached, POstgreSQL, MQTT and MQLight  
+1.0.0 Initial release  

--- a/lib/appmetrics-statsd.js
+++ b/lib/appmetrics-statsd.js
@@ -33,13 +33,59 @@ var monitor = function (host, port, prefix, suffix, globalize, cacheDns, mock, g
 		client.gauge('memory.system.used', memory.physical_used);
 		client.gauge('memory.system.total', memory.physical_total);
 	});
+	
+	monitor.on('eventloop', function handleEL(eventloop) {
+		client.gauge('eventloop.latency.min', eventloop.latency.min);
+		client.gauge('eventloop.latency.max', eventloop.latency.max);
+		client.gauge('eventloop.latency.avg', eventloop.latency.avg);
+	});
 
 	monitor.on('gc', function handleGC(gc) {
 		client.gauge('gc.size', gc.size);
 		client.gauge('gc.used', gc.used);
 		client.timing('gc.duration', gc.duration);
 	});
-        
+	
+	monitor.on('http', function handleHTTP(http) {
+		client.timing('http', http.duration)
+	});
+	
+	monitor.on('socketio', function handleSocketio(socketio) {
+		client.timing('socketio.' + socketio.method + '.' + socketio.event, socketio.duration)
+	});
+	
+	monitor.on('mysql', function handleMySQL(mysql) {
+		client.timing('mysql', mysql.duration)
+	});
+	
+	monitor.on('mongo', function handleMongo(mongo) {
+		client.timing('mongo', mongo.duration)
+	});
+	
+	monitor.on('leveldown', function handleLeveldown(leveldown) {
+		client.timing('leveldown', leveldown.duration)
+	});
+	
+	monitor.on('redis', function handleRedis(redis) {
+		client.timing('redis.' + redis.cmd, redis.duration)
+	});
+	
+	monitor.on('memcached', function handleMemcached(memcached) {
+		client.timing('memcached.' + memcached.method, memcached.duration)
+	});
+	
+	monitor.on('postgres', function handlePostgres(postgres) {
+		client.timing('postgres', postgres.duration)
+	});
+	
+	monitor.on('mqtt', function handleMQTT(mqtt) {
+		client.timing('mqtt.' + mqtt.method + '.' + mqtt.topic, mqtt.duration)
+	});
+	
+	monitor.on('mqlight', function handleMQLight(mqlight) {
+		client.timing('mqlight.' + mqlight.method + '.' + mqlight.topic, mqlight.duration)
+	});
+
 	return client;
 };
 

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "appmetrics-statsd",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "StatsD connector for Node Application Metrics",
   "main": "index.js",
   "dependencies": {
-    "appmetrics": "*",
+    "appmetrics": "^1.0.4",
     "node-statsd": "*"
   },
   "scripts": {


### PR DESCRIPTION
This is the PR for issue #1 adding support for the new data types.

It currently groups together HTTP, MySQL, MongoDB, etc events rather than having separate timers by URL or query. This is because its not 100% straightforward - particularly in the way that StatsD/Carbon wants to structure counter names etc.

This can easily be added once we have an idea of what users would like to see.