### PR TITLE
Change StatsD client instantiation so the first argument isn't lost

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -4,4 +4,4 @@ Authors ordered by first contribution:
  - Chris Bailey (https://github.com/seabaylea)
  - Toby Corbin (https://github.com/tobespc)
  - Matt Colegate (https://github.com/mattcolegate)
-
+ - Steve Kehlet (https://github.com/skehlet)

--- a/lib/appmetrics-statsd.js
+++ b/lib/appmetrics-statsd.js
@@ -19,7 +19,8 @@ var monitor = function (host, port, prefix, suffix, globalize, cacheDns, mock, g
     var monitor = appmetrics.monitor();
 
     var StatsD = require('node-statsd');
-    var client = new (Function.prototype.bind.apply(StatsD, arguments));
+    var client = Object.create(StatsD.prototype);
+    StatsD.apply(client, arguments);
 
     monitor.on('cpu', function handleCPU(cpu) {
     	client.gauge('cpu.process', cpu.process);


### PR DESCRIPTION
Hi, I ran into this problem trying to pass a custom host and port for StatsD. I discovered through `console.log`s that the first argument I passed to `require('appmetrics-statsd').StatsD` was getting lost. 

After a lot of reading I found you can either do:

```
    var client = new (Function.prototype.bind.apply(StatsD, [null].concat(Array.prototype.slice.call(arguments))));
```

or do it this way with `Object.create()`. I felt this was easier to understand. Thanks!

Some sources that helped me are:
- http://stackoverflow.com/a/6062379/296829
- http://www.2ality.com/2011/08/spreading.html
- https://github.com/facebookarchive/jstransform/pull/95/files
- http://stackoverflow.com/a/21507470/296829
  - esp. "A small note" comment
