### PR TITLE
bump appmetrics to 4.x.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,9 +134,11 @@ The connector sends the following data values to StatsD from Node Application Me
 The Node Application Metrics to StatsD Connector is licensed using an Apache v2.0 License.
 
 ### Version
-2.0.0
+3.0.0
 
 #### Version History
+3.0.0 Update appmetrics version to 4.x.x
+
 2.0.0 Update appmetrics version to 3.x.x
 
 1.0.1 Add support for Event Loop, HTTP, Socketio, MongoDB, MySQL, Leveldown, Redis, Memcached, POstgreSQL, MQTT and MQLight  

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "appmetrics-statsd",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "StatsD connector for Node Application Metrics",
   "main": "index.js",
   "dependencies": {
-    "appmetrics": "^3.0.0",
+    "appmetrics": "^4.0.0",
     "node-statsd": "*"
   },
   "scripts": {


### PR DESCRIPTION
Bump to version 4.x.x of appmetrics to enable node 10 support

See issue #11 