### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "StatsD connector for Node Application Metrics",
   "main": "index.js",
   "dependencies": {
-    "appmetrics": "^4.0.0",
+    "appmetrics": "*",
     "node-statsd": "*"
   },
   "scripts": {


### PR DESCRIPTION
Remove version dependency on appmetrics.  This way, we will automatically get the latest appmetrics when we release that so our Node support for this module will always be at the same level as appmetrics